### PR TITLE
Fix restore allocation when transitioning from an SP to a broadcast CBAP and vice versa

### DIFF
--- a/src/wifi/model/dca-txop.cc
+++ b/src/wifi/model/dca-txop.cc
@@ -294,7 +294,7 @@ DcaTxop::StartAllocationPeriod (AllocationType allocationType, AllocationID allo
       m_currentHdr = info.second;
     }
 
-  StartAccessIfNeeded ();
+  ReStartAccessIfNeeded ();
 }
 
 void

--- a/src/wifi/model/dca-txop.cc
+++ b/src/wifi/model/dca-txop.cc
@@ -275,6 +275,46 @@ DcaTxop::StartAccessIfNeeded (void)
 }
 
 void
+DcaTxop::RestoreAllocation (void)
+{
+  NS_LOG_FUNCTION (this);
+  PacketInformation info;
+  StoredPacketsCI iter = m_storedPackets.begin ();
+  if (iter == m_storedPackets.end ())
+    {
+      NS_LOG_DEBUG ("No allocations to restore");
+      return;
+    }
+
+  if (m_allocationID == 0)
+    {
+      /* Broadcast CBAP: Restore parameters and packets from the first available allocation */
+      info = iter->second;
+      m_currentPacket = info.first;
+      m_currentHdr = info.second;
+      NS_LOG_DEBUG ("Restored packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
+      m_storedPackets.erase (iter);
+    }
+  else
+    {
+      /* SP or non-broadcast CBAP: Restore parameters and packets from the provided allocation */
+      iter = m_storedPackets.find (AddressPair (m_low->GetAddress (), m_peerStation));
+      if (iter != m_storedPackets.end ())
+        {
+          info = iter->second;
+          m_currentPacket = info.first;
+          m_currentHdr = info.second;
+          NS_LOG_DEBUG ("Restored packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
+          m_storedPackets.erase (iter);
+        }
+      else
+        {
+          NS_LOG_DEBUG ("No allocation was stored with these parameters");
+        }
+    }
+}
+
+void
 DcaTxop::StartAllocationPeriod (AllocationType allocationType, AllocationID allocationID,
                                 Mac48Address peerStation, Time allocationDuration)
 {
@@ -286,14 +326,7 @@ DcaTxop::StartAllocationPeriod (AllocationType allocationType, AllocationID allo
   m_transmissionStarted = Simulator::Now ();
 
   /* Check if we have stored packet for this allocation period */
-  StoredPacketsCI it = m_storedPackets.find (m_allocationID);
-  if (it != m_storedPackets.end ())
-    {
-      PacketInformation info = it->second;
-      m_currentPacket = info.first;
-      m_currentHdr = info.second;
-    }
-
+  RestoreAllocation ();
   RestartAccessIfNeeded ();
 }
 
@@ -305,18 +338,11 @@ DcaTxop::EndAllocationPeriod (void)
   /* Store parameters related to this Allocation period which include MSDU/A-MSDU */
   if (m_currentPacket != 0)
     {
-      NS_LOG_DEBUG ("Store packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl ()
-                    << " for AllocationID=" << +m_allocationID);
-      m_storedPackets[m_allocationID] = std::make_pair (m_currentPacket, m_currentHdr);
+      NS_LOG_DEBUG ("Store packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
+      NS_ASSERT_MSG (m_low->GetAddress () == m_currentHdr.GetAddr2 (), "Current Src address should equal Hdr Src address");
+      m_storedPackets.insert (std::make_pair (AddressPair (m_currentHdr.GetAddr2 (), m_currentHdr.GetAddr1 ()),
+                                              PacketInformation (m_currentPacket, m_currentHdr)));
       m_currentPacket = 0;
-    }
-  else
-    {
-      StoredPacketsI it = m_storedPackets.find (m_allocationID);
-      if (it != m_storedPackets.end ())
-        {
-          m_storedPackets.erase (it);
-        }
     }
 }
 
@@ -459,7 +485,7 @@ DcaTxop::NotifyAccessGranted (void)
       m_fragmentNumber = 0;
       NS_LOG_DEBUG ("dequeued size=" << m_currentPacket->GetSize () <<
                     ", to=" << m_currentHdr.GetAddr1 () <<
-                    ", seq=" << m_currentHdr.GetSequenceControl ());
+                    ", seq=" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
     }
 
   if (m_stationManager->HasDmgSupported ())

--- a/src/wifi/model/dca-txop.cc
+++ b/src/wifi/model/dca-txop.cc
@@ -294,7 +294,7 @@ DcaTxop::StartAllocationPeriod (AllocationType allocationType, AllocationID allo
       m_currentHdr = info.second;
     }
 
-  ReStartAccessIfNeeded ();
+  RestartAccessIfNeeded ();
 }
 
 void

--- a/src/wifi/model/dca-txop.cc
+++ b/src/wifi/model/dca-txop.cc
@@ -341,7 +341,7 @@ DcaTxop::EndAllocationPeriod (void)
       NS_LOG_DEBUG ("Store packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
       NS_ASSERT_MSG (m_low->GetAddress () == m_currentHdr.GetAddr2 (), "Current Src address should equal Hdr Src address");
       m_storedPackets.insert (std::make_pair (AddressPair (m_currentHdr.GetAddr2 (), m_currentHdr.GetAddr1 ()),
-                                              PacketInformation (m_currentPacket, m_currentHdr)));
+                              PacketInformation (m_currentPacket, m_currentHdr)));
       m_currentPacket = 0;
     }
 }
@@ -485,7 +485,7 @@ DcaTxop::NotifyAccessGranted (void)
       m_fragmentNumber = 0;
       NS_LOG_DEBUG ("dequeued size=" << m_currentPacket->GetSize () <<
                     ", to=" << m_currentHdr.GetAddr1 () <<
-                    ", seq=" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
+                    ", seq=0x" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
     }
 
   if (m_stationManager->HasDmgSupported ())

--- a/src/wifi/model/dca-txop.h
+++ b/src/wifi/model/dca-txop.h
@@ -331,7 +331,8 @@ public:
    */
   void EndAllocationPeriod (void);
   /**
-   * Restore Allocation.
+   * Restore packet and header parameters for the suspended transmission
+   * by source and destination MAC addresses.
    */
   void RestoreAllocation (void);
 

--- a/src/wifi/model/dca-txop.h
+++ b/src/wifi/model/dca-txop.h
@@ -330,6 +330,10 @@ public:
    * End Current Contention Period.
    */
   void EndAllocationPeriod (void);
+  /**
+   * Restore Allocation.
+   */
+  void RestoreAllocation (void);
 
 protected:
   ///< DcfState associated class
@@ -454,8 +458,9 @@ protected:
   uint8_t m_fragmentNumber; //!< the fragment number
 
   /* Store packet and header for Allocation Period */
+  typedef std::pair<Mac48Address, Mac48Address> AddressPair;
   typedef std::pair<Ptr<const Packet>, WifiMacHeader> PacketInformation;
-  typedef std::map<AllocationID, PacketInformation> StoredPackets;
+  typedef std::map<AddressPair, PacketInformation> StoredPackets;
   typedef StoredPackets::iterator StoredPacketsI;
   typedef StoredPackets::const_iterator StoredPacketsCI;
   StoredPackets m_storedPackets;    //!< Stored packets based on allocation ID.

--- a/src/wifi/model/dmg-sta-wifi-mac.cc
+++ b/src/wifi/model/dmg-sta-wifi-mac.cc
@@ -1472,7 +1472,7 @@ DmgStaWifiMac::EndRelayPeriods (REDS_PAIR &pair)
           if (m_aid == m_relayLinkInfo.srcRedsAid)
             {
               /* Switching back to the direct link so change addresses of all the packets stored in MacLow and EdcaTxopN */
-              m_low->ChangeAllocationPacketsAddress (m_currentAllocationID, m_relayLinkInfo.dstRedsAddress);
+              m_low->ChangeAllocationPacketsAddress (m_relayLinkInfo.srcRedsAddress, m_relayLinkInfo.selectedRelayAddress, m_relayLinkInfo.dstRedsAddress);
               m_edca[AC_BE]->GetQueue ()->ChangePacketsReceiverAddress (m_relayLinkInfo.selectedRelayAddress,
                                                                         m_relayLinkInfo.dstRedsAddress);
             }
@@ -1657,7 +1657,7 @@ DmgStaWifiMac::StartRelayFirstPeriod (void)
     {
       SteerAntennaToward (m_relayLinkInfo.selectedRelayAddress);
       /* Restore previously suspended transmission in LowMac */
-      m_low->RestoreAllocationParameters (m_currentAllocationID);
+      m_low->RestoreAllocationParameters (m_currentAllocationID, m_relayLinkInfo.srcRedsAddress, m_relayLinkInfo.dstRedsAddress);
       m_edca[AC_BE]->StartAllocationPeriod (SERVICE_PERIOD_ALLOCATION, m_currentAllocationID, m_relayLinkInfo.selectedRelayAddress,
                                             MicroSeconds (m_relayLinkInfo.relayFirstPeriod));
       m_edca[AC_BE]->InitiateTransmission ();

--- a/src/wifi/model/dmg-sta-wifi-mac.cc
+++ b/src/wifi/model/dmg-sta-wifi-mac.cc
@@ -1472,7 +1472,8 @@ DmgStaWifiMac::EndRelayPeriods (REDS_PAIR &pair)
           if (m_aid == m_relayLinkInfo.srcRedsAid)
             {
               /* Switching back to the direct link so change addresses of all the packets stored in MacLow and EdcaTxopN */
-              m_low->ChangeAllocationPacketsAddress (m_relayLinkInfo.srcRedsAddress, m_relayLinkInfo.selectedRelayAddress, m_relayLinkInfo.dstRedsAddress);
+              m_low->ChangeAllocationPacketsAddress (m_relayLinkInfo.srcRedsAddress, m_relayLinkInfo.selectedRelayAddress,
+                                                     m_relayLinkInfo.dstRedsAddress);
               m_edca[AC_BE]->GetQueue ()->ChangePacketsReceiverAddress (m_relayLinkInfo.selectedRelayAddress,
                                                                         m_relayLinkInfo.dstRedsAddress);
             }

--- a/src/wifi/model/dmg-wifi-mac.cc
+++ b/src/wifi/model/dmg-wifi-mac.cc
@@ -328,7 +328,7 @@ DmgWifiMac::StartContentionPeriod (AllocationID allocationID, Time contentionDur
     }
   /* Allow Contention Access */
   m_dcfManager->AllowChannelAccess ();
-  /* Restore previously suspended transmission in LowMac */
+  /* Restore previously suspended transmission at MacLow*/
   m_low->RestoreAllocationParameters (allocationID, GetAddress (), GetBssid ());
   /* Signal DCA, EDCA, and SLS DCA Functions to start channel access */
   m_dca->StartAllocationPeriod (CBAP_ALLOCATION, allocationID, GetBssid (), contentionDuration);

--- a/src/wifi/model/dmg-wifi-mac.cc
+++ b/src/wifi/model/dmg-wifi-mac.cc
@@ -329,7 +329,7 @@ DmgWifiMac::StartContentionPeriod (AllocationID allocationID, Time contentionDur
   /* Allow Contention Access */
   m_dcfManager->AllowChannelAccess ();
   /* Restore previously suspended transmission in LowMac */
-  m_low->RestoreAllocationParameters (allocationID);
+  m_low->RestoreAllocationParameters (allocationID, GetAddress (), GetBssid ());
   /* Signal DCA, EDCA, and SLS DCA Functions to start channel access */
   m_dca->StartAllocationPeriod (CBAP_ALLOCATION, allocationID, GetBssid (), contentionDuration);
   for (EdcaQueues::iterator i = m_edca.begin (); i != m_edca.end (); ++i)
@@ -401,7 +401,7 @@ DmgWifiMac::ScheduleServicePeriod (uint8_t blocks, Time spStart, Time spLength, 
 void
 DmgWifiMac::StartServicePeriod (AllocationID allocationID, Time length, uint8_t peerAid, Mac48Address peerAddress, bool isSource)
 {
-  NS_LOG_FUNCTION (this << length << static_cast<uint16_t> (peerAid) << peerAddress << isSource << Simulator::Now ());
+  NS_LOG_FUNCTION (this << length << +peerAid << peerAddress << isSource << Simulator::Now ());
   m_currentAllocationID = allocationID;
   m_currentAllocation = SERVICE_PERIOD_ALLOCATION;
   m_currentAllocationLength = length;
@@ -412,7 +412,7 @@ DmgWifiMac::StartServicePeriod (AllocationID allocationID, Time length, uint8_t 
   m_servicePeriodStartedCallback (GetAddress (), peerAddress);
   SteerAntennaToward (peerAddress);
   /* Restore previously suspended transmission in LowMac */
-  m_low->RestoreAllocationParameters (allocationID);
+  m_low->RestoreAllocationParameters (allocationID, GetAddress (), peerAddress);
   m_edca[AC_BE]->StartAllocationPeriod (SERVICE_PERIOD_ALLOCATION, allocationID, peerAddress, length);
   if (isSource)
     {

--- a/src/wifi/model/dmg-wifi-scheduler.cc
+++ b/src/wifi/model/dmg-wifi-scheduler.cc
@@ -368,7 +368,7 @@ DmgWifiScheduler::GetBroadcastCbapAllocation (bool staticAllocation, uint32_t al
   uint16_t lastCbapLength = blockDuration % MAX_CBAP_BLOCK_DURATION;
   AllocationFieldList list;
   AllocationField field;
-  field.SetAllocationID (0);
+  field.SetAllocationID (BROADCAST_CBAP);
   field.SetAllocationType (CBAP_ALLOCATION);
   field.SetAsPseudoStatic (staticAllocation);
   field.SetSourceAid (AID_BROADCAST);

--- a/src/wifi/model/edca-txop-n.cc
+++ b/src/wifi/model/edca-txop-n.cc
@@ -239,7 +239,7 @@ EdcaTxopN::NotifyAccessGranted (void)
           else
             {
               NS_LOG_DEBUG ("Removed very old A-MPDU from previous allocation");
-              m_low->RemoveCurrrentAllocation ();
+              m_low->RemoveCurrentAllocation ();
             }
         }
     }

--- a/src/wifi/model/edca-txop-n.cc
+++ b/src/wifi/model/edca-txop-n.cc
@@ -229,6 +229,11 @@ EdcaTxopN::NotifyAccessGranted (void)
           if (!m_low->HasStoredAmpduExpired ())
             {
               m_low->ResumeTransmission (m_remainingDuration, this);
+              if (!m_low->IsTransmissionSuspended ())
+                {
+                  /* Check if other allocations need to be restored */
+                  m_low->RestoreAllocationParameters (m_allocationID);
+                }
               return;
             }
           else

--- a/src/wifi/model/edca-txop-n.cc
+++ b/src/wifi/model/edca-txop-n.cc
@@ -1049,8 +1049,11 @@ EdcaTxopN::StartAllocationPeriod (AllocationType allocationType, AllocationID al
           m_currentHdr = info.second;
           NS_LOG_DEBUG ("Restored packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl ());
         }
+
+      NS_LOG_DEBUG (m_queue->IsEmpty () << ", " << m_baManager->HasPackets () << ", " <<
+                    m_low->RestoredSuspendedTransmission () << ", " << m_currentPacket << ", " << m_queue->GetNPackets ());
       /* Do the contention access by DCF Manager */
-      if ((!m_queue->IsEmpty () || m_baManager->HasPackets () || m_currentPacket != 0)
+      if ((!m_queue->IsEmpty () || m_baManager->HasPackets () || m_currentPacket != 0 || !m_low->RestoredSuspendedTransmission ())
           && !m_dcf->IsAccessRequested ())
         {
           m_manager->RequestAccess (m_dcf);

--- a/src/wifi/model/edca-txop-n.cc
+++ b/src/wifi/model/edca-txop-n.cc
@@ -309,7 +309,7 @@ EdcaTxopN::NotifyAccessGranted (void)
           m_fragmentNumber = 0;
           NS_LOG_DEBUG ("dequeued size=" << m_currentPacket->GetSize () <<
                         ", to=" << m_currentHdr.GetAddr1 () <<
-                        ", seq=" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
+                        ", seq=0x" << std::hex << m_currentHdr.GetSequenceControl () << std::dec);
           if (m_currentHdr.IsQosData () && !m_currentHdr.GetAddr1 ().IsBroadcast ())
             {
               VerifyBlockAck ();
@@ -1050,9 +1050,12 @@ EdcaTxopN::StartAllocationPeriod (AllocationType allocationType, AllocationID al
       /* Check if we have stored packet for this allocation period */
       RestoreAllocation ();
 
-      NS_LOG_DEBUG (m_queue->IsEmpty () << ", " << m_baManager->HasPackets () << ", " <<
-                    m_low->RestoredSuspendedTransmission () << ", " << m_currentPacket << ", " << m_queue->GetNPackets () <<
-                    ", accessRequested=" << m_dcf->IsAccessRequested ());
+      NS_LOG_DEBUG ("IsQueueEmpty=" << m_queue->IsEmpty () 
+                    << ", HasBaManagerPkts=" << m_baManager->HasPackets () 
+                    << ", IsMacLowRestored=" << m_low->RestoredSuspendedTransmission () 
+                    << ", currentPacket=" << m_currentPacket 
+                    << ", queueSize=" << m_queue->GetNPackets () 
+                    << ", accessRequested=" << m_dcf->IsAccessRequested ());
       /* Do the contention access by DCF Manager */
       if ((!m_queue->IsEmpty () || m_baManager->HasPackets () || (m_currentPacket != 0 && !m_low->RestoredSuspendedTransmission ()))
           && !m_dcf->IsAccessRequested ())
@@ -1074,8 +1077,11 @@ EdcaTxopN::InitiateTransmission (void)
   RestoreAllocation ();
 
   /* Start access if we have packets in the queue or packets that need retransmit or non-restored transmission */
-  NS_LOG_DEBUG (m_queue->IsEmpty () << ", " << m_baManager->HasPackets () << ", " <<
-                m_low->RestoredSuspendedTransmission () << ", " << m_currentPacket << ", " << m_queue->GetNPackets ());
+  NS_LOG_DEBUG ("IsQueueEmpty=" << m_queue->IsEmpty () 
+                << ", HasBaManagerPkts=" << m_baManager->HasPackets () 
+                << ", IsMacLowRestored=" << m_low->RestoredSuspendedTransmission () 
+                << ", currentPacket=" << m_currentPacket 
+                << ", queueSize=" << m_queue->GetNPackets ());
 
   if (!m_queue->IsEmpty () || m_baManager->HasPackets ()
       || !m_low->RestoredSuspendedTransmission () || m_currentPacket != 0)

--- a/src/wifi/model/edca-txop-n.cc
+++ b/src/wifi/model/edca-txop-n.cc
@@ -232,7 +232,7 @@ EdcaTxopN::NotifyAccessGranted (void)
               if (!m_low->IsTransmissionSuspended ())
                 {
                   /* Check if other allocations need to be restored */
-                  m_low->RestoreAllocationParameters (m_allocationID);
+                  m_low->RestoreAllocationParameters (m_allocationID, m_low->GetAddress (), m_peerStation);
                 }
               return;
             }
@@ -1039,6 +1039,7 @@ EdcaTxopN::StartAllocationPeriod (AllocationType allocationType, AllocationID al
   m_allocationID = allocationID;
   m_peerStation = peerStation;
   m_allocationDuration = allocationDuration;
+
   if (m_allocationType == CBAP_ALLOCATION)
     {
       m_firstTransmission = true;
@@ -1046,13 +1047,13 @@ EdcaTxopN::StartAllocationPeriod (AllocationType allocationType, AllocationID al
 
       /* Check if we have stored packet for this allocation period */
       StoredPacketsCI it = m_storedPackets.find (m_allocationID);
-      NS_LOG_DEBUG ("StoredPackets=" << m_storedPackets.size () << " , AllocationID=" << +m_allocationID);
+      NS_LOG_UNCOND ("StoredPackets=" << m_storedPackets.size () << " , AllocationID=" << +m_allocationID);
       if (it != m_storedPackets.end ())
         {
           PacketInformation info = it->second;
           m_currentPacket = info.first;
           m_currentHdr = info.second;
-          NS_LOG_DEBUG ("Restored packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl ());
+          NS_LOG_UNCOND ("Restored packet with seq=0x" << std::hex << m_currentHdr.GetSequenceControl ());
         }
 
       NS_LOG_DEBUG (m_queue->IsEmpty () << ", " << m_baManager->HasPackets () << ", " <<

--- a/src/wifi/model/mac-low.cc
+++ b/src/wifi/model/mac-low.cc
@@ -623,16 +623,12 @@ MacLow::RestoreAllocationParameters (AllocationID allocationId, Mac48Address src
   if (m_currentAllocationID == BROADCAST_CBAP)
     {
       /* Broadcast CBAP: Restore parameters and packets from any suspended allocation */
-      for (AllocationPeriodsTableCI it = iter; it != m_allocationPeriodsTable.end (); ++it)
-        {
-          m_currentAllocation = it->second;
-          NS_LOG_UNCOND ("Restored allocation parameters with srcAddress=" << m_currentAllocation.hdr.GetAddr2 ()
-                        << ", dstAddress=" << m_currentAllocation.hdr.GetAddr1 ());
-          NS_ASSERT_MSG (m_currentSrcAddress == m_currentAllocation.hdr.GetAddr2 (), "Current address should equal hdr address");
-          m_currentDstAddress = m_currentAllocation.hdr.GetAddr1 ();
-          m_restoredSuspendedTransmission = false;
-          break;
-        }
+      m_currentAllocation = iter->second;
+      NS_LOG_UNCOND ("Restored allocation parameters with srcAddress=" << m_currentAllocation.hdr.GetAddr2 ()
+                    << ", dstAddress=" << m_currentAllocation.hdr.GetAddr1 ());
+      NS_ASSERT_MSG (m_currentSrcAddress == m_currentAllocation.hdr.GetAddr2 (), "Current Src address should equal Hdr Src address");
+      m_currentDstAddress = m_currentAllocation.hdr.GetAddr1 ();
+      m_restoredSuspendedTransmission = false;
     }
   else
     {
@@ -647,7 +643,7 @@ MacLow::RestoreAllocationParameters (AllocationID allocationId, Mac48Address src
         }
       else
         {
-          NS_LOG_DEBUG ("No allocation parameters are stored for this allocation");
+          NS_LOG_DEBUG ("No allocation parameters have been stored for this allocation");
           m_restoredSuspendedTransmission = true;
         }
     }
@@ -677,8 +673,8 @@ MacLow::StoreAllocationParameters (void)
         {
           m_currentAllocation.aggregateQueue = 0;
         }
-      NS_ASSERT_MSG (m_currentSrcAddress == m_currentHdr.GetAddr2 (), "Current src address is not equal to hdr src address");
-      AllocationPeriodsTableCI iter = m_allocationPeriodsTable.find (std::make_pair (m_currentSrcAddress, m_currentHdr.GetAddr1 ()));
+      NS_ASSERT_MSG (m_currentSrcAddress == m_currentHdr.GetAddr2 (), "Current Src address should be equal to Hdr Src address");
+      AllocationPeriodsTableCI iter = m_allocationPeriodsTable.find (AddressPair (m_currentSrcAddress, m_currentHdr.GetAddr1 ()));
       NS_ASSERT_MSG (iter == m_allocationPeriodsTable.end (), "Attempting to store existing allocation parameters");
       m_allocationPeriodsTable.insert (std::make_pair (AddressPair (m_currentSrcAddress, m_currentHdr.GetAddr1 ()), m_currentAllocation));
       m_allocationStored = true;
@@ -1702,7 +1698,7 @@ void
 MacLow::ForwardDown (Ptr<const Packet> packet, const WifiMacHeader* hdr, WifiTxVector txVector)
 {
   NS_LOG_FUNCTION (this << packet << hdr << txVector);
-  NS_LOG_DEBUG ("send " << hdr->GetTypeString () <<
+  NS_LOG_UNCOND ("send " << hdr->GetTypeString () <<
                 ", to=" << hdr->GetAddr1 () <<
                 ", size=" << packet->GetSize () <<
                 ", mode=" << txVector.GetMode  () <<

--- a/src/wifi/model/mac-low.cc
+++ b/src/wifi/model/mac-low.cc
@@ -539,6 +539,9 @@ MacLow::ResumeTransmission (Time duration, Ptr<DcaTxop> dca)
   m_currentTxVector = m_currentAllocation.txVector;
   m_ampdu = m_currentAllocation.isAmpdu;
 
+  /* Remove Allocation from allocation table as we restored it */
+  m_allocationPeriodsTable.erase (m_currentAllocationID);
+
   /* Restore Aggregate Queue contents */
   if (m_ampdu && m_currentHdr.IsQosData ())
     {
@@ -571,11 +574,10 @@ MacLow::ResumeTransmission (Time duration, Ptr<DcaTxop> dca)
     }
   else
     {
+      NS_LOG_DEBUG ("No enough time to complete this DMG transaction for Packet=" << m_currentPacket);
+      StoreAllocationParameters ();
       m_transmissionSuspended = true;
     }
-
-  /* Remove Allocation from allocation list as we restored it */
-  m_allocationPeriodsTable.erase (m_currentAllocationID);
 }
 
 void

--- a/src/wifi/model/mac-low.cc
+++ b/src/wifi/model/mac-low.cc
@@ -578,7 +578,7 @@ MacLow::ResumeTransmission (Time duration, Ptr<DcaTxop> dca)
     }
   else
     {
-      NS_LOG_DEBUG ("No enough time to complete this DMG transaction for Packet=" << m_currentPacket);
+      NS_LOG_DEBUG ("There is not enough time to complete this DMG transaction for Packet=" << m_currentPacket);
       StoreAllocationParameters ();
       m_transmissionSuspended = true;
     }

--- a/src/wifi/model/mac-low.cc
+++ b/src/wifi/model/mac-low.cc
@@ -520,7 +520,7 @@ MacLow::HasStoredAmpduExpired (void) const
 }
 
 void
-MacLow::RemoveCurrrentAllocation (void)
+MacLow::RemoveCurrentAllocation (void)
 {
   m_restoredSuspendedTransmission = true;
   m_allocationPeriodsTable.erase (AddressPair (m_currentSrcAddress, m_currentDstAddress));

--- a/src/wifi/model/mac-low.cc
+++ b/src/wifi/model/mac-low.cc
@@ -552,7 +552,7 @@ MacLow::ResumeTransmission (Time duration, Ptr<DcaTxop> dca)
     }
 
   m_txParams.SetMaximumTransmissionDuration (duration);
-  NS_LOG_UNCOND ("Resuming packet=" << m_currentPacket
+  NS_LOG_DEBUG ("Resuming tx of packet=" << m_currentPacket
                 << ", currentAllocID=" << +m_currentAllocationID
                 << ", sourceAddress=" << m_currentSrcAddress
                 << ", destAddress=" << m_currentDstAddress
@@ -622,10 +622,11 @@ MacLow::RestoreAllocationParameters (AllocationID allocationId, Mac48Address src
 
   if (m_currentAllocationID == BROADCAST_CBAP)
     {
-      /* Broadcast CBAP: Restore parameters and packets from any suspended allocation */
+      /* Broadcast CBAP: Restore parameters and packets from the first available allocation */
       m_currentAllocation = iter->second;
-      NS_LOG_UNCOND ("Restored allocation parameters with srcAddress=" << m_currentAllocation.hdr.GetAddr2 ()
-                    << ", dstAddress=" << m_currentAllocation.hdr.GetAddr1 ());
+      NS_LOG_DEBUG ("Restored allocation parameters with srcAddress=" << m_currentAllocation.hdr.GetAddr2 ()
+                    << ", dstAddress=" << m_currentAllocation.hdr.GetAddr1 ()
+                    << ", seq=0x" << std::hex <<  m_currentAllocation.hdr.GetSequenceControl () << std::dec);
       NS_ASSERT_MSG (m_currentSrcAddress == m_currentAllocation.hdr.GetAddr2 (), "Current Src address should equal Hdr Src address");
       m_currentDstAddress = m_currentAllocation.hdr.GetAddr1 ();
       m_restoredSuspendedTransmission = false;
@@ -636,9 +637,10 @@ MacLow::RestoreAllocationParameters (AllocationID allocationId, Mac48Address src
       iter = m_allocationPeriodsTable.find (AddressPair (m_currentSrcAddress, m_currentDstAddress));
       if (iter != m_allocationPeriodsTable.end ())
         {
-          NS_LOG_UNCOND ("Restored allocation parameters with srcAddress=" << m_currentSrcAddress
-                        << ", dstAddress=" << m_currentDstAddress);
           m_currentAllocation = iter->second;
+          NS_LOG_DEBUG ("Restored allocation parameters with srcAddress=" << m_currentSrcAddress
+                        << ", dstAddress=" << m_currentDstAddress
+                        << ", seq=0x" << std::hex <<  m_currentAllocation.hdr.GetSequenceControl () << std::dec);
           m_restoredSuspendedTransmission = false;
         }
       else
@@ -678,7 +680,7 @@ MacLow::StoreAllocationParameters (void)
       NS_ASSERT_MSG (iter == m_allocationPeriodsTable.end (), "Attempting to store existing allocation parameters");
       m_allocationPeriodsTable.insert (std::make_pair (AddressPair (m_currentSrcAddress, m_currentHdr.GetAddr1 ()), m_currentAllocation));
       m_allocationStored = true;
-      NS_LOG_UNCOND ("Storing packet=" << m_currentPacket
+      NS_LOG_DEBUG ("Storing packet=" << m_currentPacket
                     << ", currentAllocID=" << +m_currentAllocationID
                     << ", sourceAddress=" << m_currentSrcAddress
                     << ", destAddress=" << m_currentHdr.GetAddr1 ()
@@ -1698,7 +1700,7 @@ void
 MacLow::ForwardDown (Ptr<const Packet> packet, const WifiMacHeader* hdr, WifiTxVector txVector)
 {
   NS_LOG_FUNCTION (this << packet << hdr << txVector);
-  NS_LOG_UNCOND ("send " << hdr->GetTypeString () <<
+  NS_LOG_DEBUG ("send " << hdr->GetTypeString () <<
                 ", to=" << hdr->GetAddr1 () <<
                 ", size=" << packet->GetSize () <<
                 ", mode=" << txVector.GetMode  () <<

--- a/src/wifi/model/mac-low.h
+++ b/src/wifi/model/mac-low.h
@@ -391,12 +391,12 @@ public:
    */
   void ResumeTransmission (Time duration, Ptr<DcaTxop> dca);
 
-  void ChangeAllocationPacketsAddress (AllocationID allocationId, Mac48Address destAdd);
+  void ChangeAllocationPacketsAddress (Mac48Address currentSrc, Mac48Address currentDst, Mac48Address destAdd);
   /**
    * Restore Allocation Parameters for specific allocation SP or CBAP.
    * \param allocationId The ID of the allocation.
    */
-  void RestoreAllocationParameters (AllocationID allocationId);
+  void RestoreAllocationParameters (AllocationID allocationId, Mac48Address srcAddress, Mac48Address dstAddress);
 
   void StoreAllocationParameters (void);
   /**
@@ -1147,12 +1147,14 @@ double mpduSnr;
     Ptr<WifiMacQueue> aggregateQueue;
   } AllocationParameters;
 
-  typedef std::map<AllocationID, AllocationParameters> AllocationPeriodsTable;
+  typedef std::pair<Mac48Address, Mac48Address> AddressPair;
+  typedef std::map<AddressPair, AllocationParameters> AllocationPeriodsTable;
   typedef AllocationPeriodsTable::const_iterator AllocationPeriodsTableCI;
   typedef AllocationPeriodsTable::iterator AllocationPeriodsTableI;
   AllocationPeriodsTable m_allocationPeriodsTable;
   AllocationID m_currentAllocationID;
-  AllocationID m_restoredAllocationID;
+  Mac48Address m_currentSrcAddress;
+  Mac48Address m_currentDstAddress;
   AllocationParameters m_currentAllocation;   //!< Current allocation parameters.
   bool m_transmissionSuspended;               //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.
   bool m_allocationStored;                    //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.

--- a/src/wifi/model/mac-low.h
+++ b/src/wifi/model/mac-low.h
@@ -1152,6 +1152,7 @@ double mpduSnr;
   typedef AllocationPeriodsTable::iterator AllocationPeriodsTableI;
   AllocationPeriodsTable m_allocationPeriodsTable;
   AllocationID m_currentAllocationID;
+  AllocationID m_restoredAllocationID;
   AllocationParameters m_currentAllocation;   //!< Current allocation parameters.
   bool m_transmissionSuspended;               //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.
   bool m_allocationStored;                    //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.

--- a/src/wifi/model/mac-low.h
+++ b/src/wifi/model/mac-low.h
@@ -390,23 +390,40 @@ public:
    * \param listener
    */
   void ResumeTransmission (Time duration, Ptr<DcaTxop> dca);
-
+  /**
+   * Change the Destination MAC address for a specific traffic flow.
+   * \param currentSrc The current source MAC address of the traffic flow.
+   * \param currentDst The current dest MAC address of the traffic flow.
+   * \param destAdd The new dest MAC address for the traffic flow.
+   *
+   * This function is used during relay operations in IEEE 802.11ad.
+   */
   void ChangeAllocationPacketsAddress (Mac48Address currentSrc, Mac48Address currentDst, Mac48Address destAdd);
   /**
-   * Restore Allocation Parameters for specific allocation SP or CBAP.
-   * \param allocationId The ID of the allocation.
+   * Restore Allocation Parameters for a specific traffic flow.
+   * \param allocationId The ID of the current allocation (SP, CBAP or broadcast CBAP).
+   * \param srcAddress The source MAC address of the traffic flow.
+   * \param dstAddress The destination MAC address of the traffic flow.
    */
   void RestoreAllocationParameters (AllocationID allocationId, Mac48Address srcAddress, Mac48Address dstAddress);
-
+  /**
+   * Store the Allocation Parameters for a specific traffic flow.
+   */
   void StoreAllocationParameters (void);
   /**
-   * Check whether a transmission has been suspended due to time constraints for the restored allocation.
-   * \return True if transmission has been suspended otherwise false.
+   * Check whether a transmission has been suspended due to time constraints for the restored traffic flow.
+   * \return True if transmission has been suspended otherwise False.
    */
   bool IsTransmissionSuspended (void) const;
-
+  /**
+   * Check whether a previously suspended transmission has been restored.
+   * \return False if the transmission of a restored traffic flow needs to be resumed otherwise True. 
+   */
   bool RestoredSuspendedTransmission (void) const;
-
+  /**
+   * Check whether, at MacLow, a transmission has been stored.
+   * \return True if the parameters of the current traffic flow have been stored otherwise False 
+   */
   bool StoredCurrentAllocation (void) const;
   /**
    * \param packet packet received
@@ -1151,14 +1168,14 @@ double mpduSnr;
   typedef std::map<AddressPair, AllocationParameters> AllocationPeriodsTable;
   typedef AllocationPeriodsTable::const_iterator AllocationPeriodsTableCI;
   typedef AllocationPeriodsTable::iterator AllocationPeriodsTableI;
-  AllocationPeriodsTable m_allocationPeriodsTable;
-  AllocationID m_currentAllocationID;
-  Mac48Address m_currentSrcAddress;
-  Mac48Address m_currentDstAddress;
-  AllocationParameters m_currentAllocation;   //!< Current allocation parameters.
-  bool m_transmissionSuspended;               //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.
-  bool m_allocationStored;                    //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.
-  bool m_restoredSuspendedTransmission;       //!< Flag to indicate that we have more time to traansmit more packets.
+  AllocationPeriodsTable m_allocationPeriodsTable;  //!< Map that contains the parameters associated with a suspended transmission.
+  AllocationID m_currentAllocationID;               //!< The allocation ID of the current channel access period.
+  Mac48Address m_currentSrcAddress;                 //!< The source MAC address for the current traffic flow.
+  Mac48Address m_currentDstAddress;                 //!< The destination MAC address for the current traffic flow.
+  AllocationParameters m_currentAllocation;         //!< Currently restored allocation parameters.
+  bool m_transmissionSuspended;                     //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.
+  bool m_allocationStored;                          //!< Flag to indicate that we have suspended transmission applicable for 802.11ad only.
+  bool m_restoredSuspendedTransmission;             //!< Flag to indicate that we have more time to traansmit more packets.
 };
 
 } //namespace ns3

--- a/src/wifi/model/mac-low.h
+++ b/src/wifi/model/mac-low.h
@@ -382,9 +382,9 @@ public:
    */
   bool HasStoredAmpduExpired (void) const;
   /**
-   * Remove currrent allocation if HasStoredAmpduExpired returns true.
+   * Remove current allocation if HasStoredAmpduExpired returns true.
    */
-  void RemoveCurrrentAllocation (void);
+  void RemoveCurrentAllocation (void);
   /**
    * Resume Transmission for the current allocation if transmission has been suspended.
    * \param listener


### PR DESCRIPTION
Now a STA can communicate smoothly between SPs and broadcast CBAPs with the AP and vice versa. Still, the communication between two STAs with allocated SP needs to be investigated during a broadcast CBAP.

Fixed #11 
Fixed #6  