### PR TITLE
Add support to periodic allocations 

### DIFF
--- a/src/wifi/model/dmg-sta-wifi-mac.cc
+++ b/src/wifi/model/dmg-sta-wifi-mac.cc
@@ -1300,7 +1300,7 @@ DmgStaWifiMac::ScheduleAllocationBlocks (AllocationField &field, STA_ROLE role)
           NS_LOG_INFO ("Schedule SP Block [" << i << "] at " << spStart << " till " << spStart + spLength);
           Simulator::Schedule (spStart, &DmgStaWifiMac::InitiateAllocationPeriod, this,
                                field.GetAllocationID (), field.GetSourceAid (), field.GetDestinationAid (), spLength, role);
-          spStart += spLength + spPeriod + GUARD_TIME;
+          spStart += spPeriod;
         }
     }
   else

--- a/src/wifi/model/dmg-wifi-mac.cc
+++ b/src/wifi/model/dmg-wifi-mac.cc
@@ -384,7 +384,7 @@ DmgWifiMac::ScheduleServicePeriod (uint8_t blocks, Time spStart, Time spLength, 
           Simulator::Schedule (spStart, &DmgWifiMac::StartServicePeriod, this,
                                allocationID, spLength, peerAid, peerAddress, isSource);
           Simulator::Schedule (spStart + spLength, &DmgWifiMac::EndServicePeriod, this);
-          spStart += spLength + spPeriod + GUARD_TIME;
+          spStart += spPeriod;
         }
     }
   else

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -38,20 +38,9 @@ TypeId
 PeriodicDmgWifiScheduler::GetTypeId (void)
 {
   static TypeId tid = TypeId ("ns3::PeriodicDmgWifiScheduler")
-      .SetParent<DmgWifiScheduler> ()
-      .SetGroupName ("Wifi")
-      .AddConstructor<PeriodicDmgWifiScheduler> ()
-
-      .AddAttribute ("MinBroadcastCbapDuration", "The minimum duration in microseconds of a broadcast CBAP in the DTI",
-                     UintegerValue (4096),
-                     MakeUintegerAccessor (&PeriodicDmgWifiScheduler::m_minBroadcastCbapDuration),
-                     MakeUintegerChecker<uint32_t> ())
-      .AddAttribute ("InterAllocationDistance", "The time distance in microseconds between two adjacent allocations "
-                     "This distance will be allocated as broadcast CBAP",
-                     UintegerValue (10),
-                     MakeUintegerAccessor (&PeriodicDmgWifiScheduler::m_interAllocationDistance),
-                     MakeUintegerChecker<uint32_t> (10, 65535))
-  ;
+    .SetParent<DmgWifiScheduler> ()
+    .SetGroupName ("Wifi")
+    .AddConstructor<PeriodicDmgWifiScheduler> ();
   return tid;
 }
 
@@ -183,10 +172,6 @@ PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecEle
       // spInterval is going to be passed to AddAllocationPeriod to specify the 
       // distance between consecutive periodic SPs
       uint32_t spInterval = uint32_t (m_biDuration.GetMicroSeconds () / allocPeriod);
-      if (spInterval - allocDuration < m_minBroadcastCbapDuration)
-        {
-          NS_FATAL_ERROR ("These settings cannot guarantee minimum CBAP duration.");
-        }
 
       NS_LOG_DEBUG ("Allocation Period " << uint32_t (allocPeriod) << " AllocDuration " << allocDuration << " Multiple " << isMultiple);
       NS_LOG_DEBUG ("Schedule one SP every " << spInterval);
@@ -507,7 +492,8 @@ void
 PeriodicDmgWifiScheduler::AddBroadcastCbapAllocations (void)
 {
   NS_LOG_FUNCTION (this);
-  /* Addts allocation list is copied to the allocation list */
+  
+  // Addts allocation list is copied to the allocation list 
 
   m_allocationList = m_addtsAllocationList;
   AllocationFieldList broadcastCbapList;

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -208,7 +208,7 @@ PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecEle
     }
 
   uint32_t endAlloc;
-  for (uint8_t i = 0; i < blocks.size (); ++i)
+  for (uint8_t i = 0; i < blocks.size(); ++i)
     {
       NS_LOG_DEBUG ("Reserve from " << blocks[i] << " for " << allocDuration);
       endAlloc = blocks[i] + allocDuration + m_guardTime;
@@ -305,15 +305,12 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAlloc, uint32_t en
       if (startSlot == startAlloc)
         {
           it->first = endAlloc;
-          // m_availableSlots.insert (it, std::make_pair (endAlloc, endSlot));
-          // it = m_availableSlots.erase (it);
           break;
         }
       else if (startSlot < startAlloc && endSlot > endAlloc)
         {
           it->first = endAlloc;
           m_availableSlots.insert (it, std::make_pair (startSlot, startAlloc));
-          // m_availableSlots.insert (it, std::make_pair (endAlloc, endSlot));
           break;
         }
     }
@@ -333,7 +330,6 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAlloc, uint32_t ne
   NS_LOG_FUNCTION (this << startAlloc << newEndAlloc << difference);
 
   uint32_t startSlot;
-  // uint32_t endSlot;
 
   // something has changed in the allocation list, need to change the list of 
   // available slots accordingly
@@ -341,7 +337,6 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAlloc, uint32_t ne
   for (auto it = m_availableSlots.begin (); it != m_availableSlots.end (); ++it)
     {
       startSlot = it->first;
-      // endSlot = it->second;
 
       if (startSlot < startAlloc)
         {
@@ -359,8 +354,6 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAlloc, uint32_t ne
                 {
                   // two adjacent available slots are merged 
                   it->first = newEndAlloc;
-                  // m_availableSlots.insert (it, std::make_pair (newEndAlloc, endSlot));
-                  // it = m_availableSlots.erase (it);
                   keepSearching = false;
                   break;
                 }

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -332,29 +332,30 @@ PeriodicDmgWifiScheduler::AddBroadcastCbapAllocations (void)
 {
   NS_LOG_FUNCTION (this);
   /* Addts allocation list is copied to the allocation list */
-  
+
   m_allocationList = m_addtsAllocationList;
   AllocationFieldList broadcastCbapList;
-  
+
   // fill all the remaining available slots with broadcast CBAPs
-  
-  for(auto it = m_availableSlots.begin(); it != m_availableSlots.end(); ++it)
-  {
-    broadcastCbapList = GetBroadcastCbapAllocation (true, it->first, it->second - it->first);
-    m_remainingDtiTime -= it->second - it->first;
-    m_allocationList.insert (m_allocationList.begin(), broadcastCbapList.begin(), broadcastCbapList.end());
-    NS_LOG_DEBUG("Added broadcast CBAPs list of size: " << broadcastCbapList.size () << " for a total duration of " << it->second - it->first);
-  }
-  
-  sort(m_allocationList.begin(), 
-        m_allocationList.end(), 
+
+  for (const auto & slot : m_availableSlots)
+    {
+      broadcastCbapList = GetBroadcastCbapAllocation (true, slot.first, slot.second - slot.first);
+      m_remainingDtiTime -= slot.second - slot.first;
+      m_allocationList.insert (m_allocationList.begin (), broadcastCbapList.begin (), broadcastCbapList.end ());
+      NS_LOG_DEBUG ("Added broadcast CBAPs list of size: " << broadcastCbapList.size () << " for a total duration of " << slot.second - slot.first);
+    }
+
+  sort (m_allocationList.begin (),
+        m_allocationList.end (),
         [](const AllocationField& lhs, const AllocationField& rhs){
-            return lhs.GetAllocationStart() < rhs.GetAllocationStart();});
-  
-  for(auto it = m_allocationList.begin(); it != m_allocationList.end(); ++it)
-  {
-    NS_LOG_UNCOND("Allocation element start at: " << it->GetAllocationStart () << " periodicity " << it->GetAllocationBlockPeriod() << " duration " << it->GetAllocationBlockDuration());
-  }
+      return lhs.GetAllocationStart () < rhs.GetAllocationStart ();
+    });
+
+  for (const auto & alloc: m_allocationList)
+    {
+      NS_LOG_DEBUG ("Allocation element start at: " << alloc.GetAllocationStart () << " periodicity " << alloc.GetAllocationBlockPeriod () << " duration " << alloc.GetAllocationBlockDuration ());
+    }
 
 }
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -170,7 +170,7 @@ PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecEle
 }
 
 void
-PeriodicDmgWifiScheduler::UpdateAvailableSlots(uint32_t startPeriodicAllocation, uint32_t endAlloc)
+PeriodicDmgWifiScheduler::UpdateAvailableSlots(uint32_t startAllocation, uint32_t endAlloc)
 {
     NS_LOG_FUNCTION(this);
 
@@ -178,21 +178,20 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots(uint32_t startPeriodicAllocation,
 
     for (auto it = m_availableSlots.begin() ; it != m_availableSlots.end(); ++it)
     {
-      //NS_LOG_DEBUG("Available slot from " << it->first << " to " << it->second);
 
-      if (it->second < startPeriodicAllocation)
+      if (it->first > endAlloc || it->second < startAllocation)
       {
         newDTI.push_back(*it);
         continue;
       }
 
-      if(it->first == startPeriodicAllocation)
+      if(it->first == startAllocation)
       {
         newDTI.push_back(std::make_pair(endAlloc, it->second));
       }
-      else if (it->first < startPeriodicAllocation && it->second > endAlloc)
+      else if (it->first < startAllocation && it->second > endAlloc)
       {
-        newDTI.push_back(std::make_pair(it->first, startPeriodicAllocation));
+        newDTI.push_back(std::make_pair(it->first, startAllocation));
         newDTI.push_back(std::make_pair(endAlloc, it->second));
       }
     }

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -1,0 +1,120 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2020, University of Padova, Department of Information
+ * Engineering, SIGNET Lab.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ */
+
+#include <ns3/assert.h>
+#include <ns3/log.h>
+#include <ns3/simulator.h>
+#include <ns3/pointer.h>
+#include <ns3/boolean.h>
+
+#include "periodic-dmg-wifi-scheduler.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("PeriodicDmgWifiScheduler");
+
+NS_OBJECT_ENSURE_REGISTERED (PeriodicDmgWifiScheduler);
+
+TypeId
+PeriodicDmgWifiScheduler::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::PeriodicDmgWifiScheduler")
+      .SetParent<DmgWifiScheduler> ()
+      .SetGroupName ("Wifi")
+      .AddConstructor<PeriodicDmgWifiScheduler> ()
+
+      .AddAttribute ("MinBroadcastCbapDuration", "The minimum duration in microseconds of a broadcast CBAP in the DTI",
+                     UintegerValue (4096),
+                     MakeUintegerAccessor (&PeriodicDmgWifiScheduler::m_minBroadcastCbapDuration),
+                     MakeUintegerChecker<uint32_t> ())
+      .AddAttribute ("InterAllocationDistance", "The time distance in microseconds between two adjacent allocations "
+                     "This distance will be allocated as broadcast CBAP",
+                     UintegerValue (10),
+                     MakeUintegerAccessor (&PeriodicDmgWifiScheduler::m_interAllocationDistance),
+                     MakeUintegerChecker<uint32_t> (10, 65535))
+  ;
+  return tid;
+}
+
+PeriodicDmgWifiScheduler::PeriodicDmgWifiScheduler ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+PeriodicDmgWifiScheduler::~PeriodicDmgWifiScheduler ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+void
+PeriodicDmgWifiScheduler::DoDispose ()
+{
+  NS_LOG_FUNCTION (this);
+  DmgWifiScheduler::DoDispose ();
+}
+
+void
+PeriodicDmgWifiScheduler::UpdateStartAndRemainingTime (void)
+{
+  NS_LOG_FUNCTION (this);
+}
+
+void
+PeriodicDmgWifiScheduler::AdjustExistingAllocations (AllocationFieldListI iter, uint32_t duration, bool isToAdd)
+{
+  NS_LOG_FUNCTION (this << duration << isToAdd);
+}
+
+uint32_t
+PeriodicDmgWifiScheduler::GetAllocationDuration (uint32_t minAllocation, uint32_t maxAllocation)
+{
+  NS_LOG_FUNCTION (this << minAllocation << maxAllocation);
+  return ((minAllocation + maxAllocation) / 2);
+}
+
+StatusCode
+PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecElement &dmgTspec, const DmgAllocationInfo &info)
+{
+  NS_LOG_FUNCTION (this);
+
+  StatusCode status;
+
+  return status;
+}
+
+StatusCode
+PeriodicDmgWifiScheduler::ModifyExistingAllocation (uint8_t sourceAid, const DmgTspecElement &dmgTspec, const DmgAllocationInfo &info)
+{
+  NS_LOG_FUNCTION (this);
+
+  StatusCode status;
+
+  return status;
+}
+
+void
+PeriodicDmgWifiScheduler::AddBroadcastCbapAllocations (void)
+{
+  NS_LOG_FUNCTION (this);
+
+}
+
+} // namespace ns3

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -219,6 +219,39 @@ void
 PeriodicDmgWifiScheduler::AddBroadcastCbapAllocations (void)
 {
   NS_LOG_FUNCTION (this);
+  /* Addts allocation list is copied to the allocation list */
+  m_allocationList = m_addtsAllocationList;
+  AllocationFieldList broadcastCbapList;
+
+  // fill all the remaining available slots with broadcast CBAPs
+
+  auto itSlot = m_availableSlots.begin();
+  for(auto itAll = m_allocationList.begin(); itAll != m_allocationList.end(); ++itAll)
+  {
+    auto itNextAll = itAll + 1;
+    uint32_t start = itAll->GetAllocationStart ();
+    uint32_t end =  start + itAll->GetAllocationBlockDuration () + m_guardTime;
+
+    NS_LOG_DEBUG("Allocation start: " << start << " end: " << end);
+
+    if ( itNextAll != m_allocationList.end() )
+    {
+      if (itSlot->first >= end && itSlot->first < itNextAll->GetAllocationStart ())
+      {
+        broadcastCbapList = GetBroadcastCbapAllocation (true, itSlot->first, itSlot->second - itSlot->first);
+        itAll = m_allocationList.insert (itNextAll, broadcastCbapList.begin (), broadcastCbapList.end ());
+        itAll += broadcastCbapList.size () - 1;
+
+        NS_LOG_DEBUG("Added broadcast CBAPs list of size: " << broadcastCbapList.size () << " for a total duration of " << itSlot->second - itSlot->first);
+
+        itSlot++;
+      }
+    }
+
+  }
+
+  m_availableSlots.clear();
+  m_remainingDtiTime = 0;
 
 }
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -75,17 +75,23 @@ PeriodicDmgWifiScheduler::DoDispose ()
 void
 PeriodicDmgWifiScheduler::UpdateStartAndRemainingTime (void)
 {
+  // for the periodic scheduler, m_allocationStartTime is useless, since the addition
+  // of new SPs is consecutive 
   NS_LOG_FUNCTION (this);
   if (m_addtsAllocationList.empty ())
     {
-      /* No existing allocations */
-      m_allocationStartTime = 0;
+      // no existing allocations
       m_remainingDtiTime = m_dtiDuration.GetMicroSeconds ();
-      m_availableSlots.push_back(std::make_pair(0, m_dtiDuration.GetMicroSeconds ()));
+      m_availableSlots.push_back (std::make_pair (0, m_dtiDuration.GetMicroSeconds ()));
     }
   else
     {
-      //TODO
+      // if there are existing allocations, update DTI time just for consistency
+      m_remainingDtiTime = 0;
+      for (const auto & slot: m_availableSlots)
+      {
+        m_remainingDtiTime += (slot.second - slot.first);
+      }
     }
 }
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -78,9 +78,9 @@ PeriodicDmgWifiScheduler::UpdateStartAndRemainingTime (void)
       // if there are existing allocations, update DTI time just for consistency
       m_remainingDtiTime = 0;
       for (const auto & slot: m_availableSlots)
-      {
-        m_remainingDtiTime += (slot.second - slot.first);
-      }
+        {
+          m_remainingDtiTime += (slot.second - slot.first);
+        }
     }
 }
 
@@ -88,46 +88,46 @@ void
 PeriodicDmgWifiScheduler::AdjustExistingAllocations (AllocationFieldListI iter, uint32_t duration, bool isToAdd)
 {
   NS_LOG_FUNCTION (this << duration << isToAdd);
-  
+
   // This method is called upon a DelTsRequest or after the cleanup of 
   // non-pseudostatic allocations.
   // In this version of the periodic scheduler, existing allocations are not shifted 
   // to fill the created gaps but only the vector listing the available slots is updated.
   // For this reason, the current input parameters are useless.
-   
+
   auto addtsListCopy = m_addtsAllocationList;
-  
+
   // sort the copy to simplify the process of going through the allocation list
   sort (addtsListCopy.begin (),
         addtsListCopy.end (),
         [](const AllocationField& lhs, const AllocationField& rhs){
       return lhs.GetAllocationStart () < rhs.GetAllocationStart ();
     });
-  
+
   uint32_t startSlot = 0;
   std::vector<std::pair<uint32_t, uint32_t> > newDTI; 
-  
+
   for (const auto & allocation: addtsListCopy)
-  {
-    // this loop goes through the list of allocations, spotting all the available
-    // slots and adding them to the list
-    if (startSlot < allocation.GetAllocationStart())
     {
-      newDTI.push_back (std::make_pair (startSlot, allocation.GetAllocationStart()));
+      // this loop goes through the list of allocations, spotting all the available
+      // slots and adding them to the list
+      if (startSlot < allocation.GetAllocationStart ())
+        {
+          newDTI.push_back (std::make_pair (startSlot, allocation.GetAllocationStart ()));
+        }
+
+      startSlot = allocation.GetAllocationStart () + allocation.GetAllocationBlockDuration () + m_guardTime;
     }
-    
-    startSlot = allocation.GetAllocationStart() + allocation.GetAllocationBlockDuration() + m_guardTime;
-  }
-  
+
   // the following check ensure that if there is a trailing available slot in the DTI,
   // it will be correctly considered and added to the list.
   if (startSlot < m_dtiDuration.GetMicroSeconds ())
-  {
-    newDTI.push_back (std::make_pair (startSlot,  m_dtiDuration.GetMicroSeconds ()));
-  }
-  
+    {
+      newDTI.push_back (std::make_pair (startSlot,  m_dtiDuration.GetMicroSeconds ()));
+    }
+
   m_availableSlots = newDTI;
-  
+
 }
 
 uint32_t
@@ -168,7 +168,7 @@ PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecEle
         {
           NS_FATAL_ERROR ("Multiple BI periodicity is not supported yet.");
         }
-      
+
       // spInterval is going to be passed to AddAllocationPeriod to specify the 
       // distance between consecutive periodic SPs
       uint32_t spInterval = uint32_t (m_biDuration.GetMicroSeconds () / allocPeriod);
@@ -232,7 +232,7 @@ PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecEle
               endAlloc = AllocateSingleContiguousBlock (info.GetAllocationID (), info.GetAllocationType (), info.IsPseudoStatic (),
                                                         sourceAid, info.GetDestinationAid (), it->first, allocDuration);
               m_remainingDtiTime -= (allocDuration + m_guardTime);
-              
+
               // The following function modifies m_availableSlots, on which this
               // loop is iterating. Commonly, it is a bad practice but, as we break 
               // the loop if we enter this condition, the damage is avoided.
@@ -325,7 +325,7 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAllocation, uint32
   NS_LOG_FUNCTION (this);
 
   std::vector<std::pair<uint32_t, uint32_t> > newDTI;
-  
+
   if (difference > 0)
     {
       // something has changed in the allocation list, need to change the list of 
@@ -361,7 +361,7 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAllocation, uint32
                       newDTI.push_back (slot);
                       search = false;
                     }
-                  NS_ASSERT_MSG(difference <= (slot.first - endAlloc), "Something broke in runtime, check the update of the available slots.");
+                  NS_ASSERT_MSG (difference <= (slot.first - endAlloc), "Something broke in runtime, check the update of the available slots.");
                 }
               else
                 {
@@ -379,7 +379,7 @@ PeriodicDmgWifiScheduler::UpdateAvailableSlots (uint32_t startAllocation, uint32
               newDTI.push_back (slot);
               continue;
             }
-          
+
           if (slot.first == startAllocation)
             {
               newDTI.push_back (std::make_pair (endAlloc, slot.second));
@@ -458,10 +458,10 @@ PeriodicDmgWifiScheduler::ModifyExistingAllocation (uint8_t sourceAid, const Dmg
       timeDifference = currentDuration - newDuration;
       allocation->SetAllocationBlockDuration (newDuration);
       status.SetSuccess ();
-      
+
       uint32_t startAlloc = allocation->GetAllocationStart ();
       uint32_t endAlloc = allocation->GetAllocationStart () + allocation->GetAllocationBlockDuration () + m_guardTime;
-      
+
       uint16_t allocPeriod = allocation->GetAllocationBlockPeriod ();
       if (allocPeriod != 0)
         {
@@ -469,7 +469,7 @@ PeriodicDmgWifiScheduler::ModifyExistingAllocation (uint8_t sourceAid, const Dmg
           // and update the available slots in the DTI accordingly.
           // TODO: update also the number of blocks if the new duration allows to 
           // add further blocks
-          uint8_t blocks = allocation->GetNumberOfBlocks();
+          uint8_t blocks = allocation->GetNumberOfBlocks ();
           for (uint8_t i = 0; i < blocks; i++)
             {
               NS_LOG_DEBUG ("Modify SP Block [" << +i << "] at " << startAlloc << " till " << endAlloc);
@@ -480,7 +480,7 @@ PeriodicDmgWifiScheduler::ModifyExistingAllocation (uint8_t sourceAid, const Dmg
         }
       else
         {
-          UpdateAvailableSlots (startAlloc, endAlloc, timeDifference);          
+          UpdateAvailableSlots (startAlloc, endAlloc, timeDifference);
         }
 
     }
@@ -492,7 +492,7 @@ void
 PeriodicDmgWifiScheduler::AddBroadcastCbapAllocations (void)
 {
   NS_LOG_FUNCTION (this);
-  
+
   // Addts allocation list is copied to the allocation list 
 
   m_allocationList = m_addtsAllocationList;

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -75,6 +75,17 @@ void
 PeriodicDmgWifiScheduler::UpdateStartAndRemainingTime (void)
 {
   NS_LOG_FUNCTION (this);
+  if (m_addtsAllocationList.empty ())
+    {
+      /* No existing allocations */
+      m_allocationStartTime = 0;
+      m_remainingDtiTime = m_dtiDuration.GetMicroSeconds ();
+      m_availableSlots.push_back(std::make_pair(0, m_dtiDuration.GetMicroSeconds ()));
+    }
+  else
+    {
+      //TODO
+    }
 }
 
 void

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.cc
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.cc
@@ -198,6 +198,73 @@ PeriodicDmgWifiScheduler::AddNewAllocation (uint8_t sourceAid, const DmgTspecEle
   return status;
 }
 
+uint8_t
+PeriodicDmgWifiScheduler::VerifyAvailableSlots(uint32_t allocDuration, uint32_t spInterval)
+{
+    NS_LOG_FUNCTION(this);
+    
+    auto it = m_availableSlots.begin();
+    uint32_t startAlloc = it->first;
+    uint32_t slotDuration = 0;
+    uint8_t blocks = 0;
+    
+    while (it != m_availableSlots.end())
+    {
+      if (startAlloc < it->first)
+      {
+        // Periodicity has been broken, we stop the algorithm.
+        break;
+      }
+      
+      slotDuration = it->second - startAlloc;
+      
+      if(allocDuration + m_guardTime > slotDuration)
+      {
+        if(blocks == 0)
+        {
+          // We go on until we eventually find the first available slot that fits our SP.
+          // Note that this also cover the condition where no slot satisfies the requirement. 
+          ++it;
+          continue;
+        }
+        else
+        {
+          // If we already allocated one or more periodic SPs, now the periodicity 
+          // is broken and we need to stop the algorithm.
+          break;
+        }
+      }
+    
+      blocks++;
+      startAlloc += spInterval;
+             
+      // Immediately check the next periodic periodic allocation, with respect to the
+      // current available slot that we are using  
+      
+      if (startAlloc == it->second)
+      {
+        // If the next SP should start at the end of the current slot, we cannot add it and the algorithm stops.
+        break;        
+      }
+      else if (startAlloc < it->second)
+      {
+        // If the the next SP should start in the current slot, we immediately check if there is 
+        // enough free time to place it, otherwise the algorithm stops.
+        if (startAlloc + allocDuration + m_guardTime > it->second)
+        {
+          break;
+        }    
+      }
+      else
+      {
+        // We pass to the next slot only if startAlloc goes beyond the end of the current one. 
+        ++it;
+      }
+    }
+    
+    return blocks;
+}
+
 void
 PeriodicDmgWifiScheduler::UpdateAvailableSlots(uint32_t startAllocation, uint32_t endAlloc)
 {

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -84,7 +84,14 @@ protected:
   virtual void AddBroadcastCbapAllocations (void);
 
 private:
-
+  
+  /**
+   * Verify if there is enough time in the DTI to allocate periodic SPs.
+   * \param allocDuration the duration associated to the SPs.
+   * \param spInterval time between two consecutive periodic SPs.
+   * \return number of SPs that can be allocated in the DTI
+   */
+  uint8_t VerifyAvailableSlots(uint32_t allocDuration, uint32_t spInterval);
   void UpdateAvailableSlots(uint32_t startAllocation, uint32_t endAlloc);
 
   uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -93,11 +93,11 @@ private:
   uint8_t GetAvailableBlocks (uint32_t allocDuration, uint32_t spInterval);
   /**
    * Update the list of available time slots in the DTI.
-   * \param startAllocation start time of the allocation that has to be excluded from the available time.
+   * \param startAlloc start time of the allocation that has to be excluded from the available time.
    * \param endAlloc end time of the allocation that has to be excluded from the available time.
    * \param difference if not equal to 0, it represents how much an allocation has been reduced.
    */
-  void UpdateAvailableSlots (uint32_t startAllocation, uint32_t endAlloc, uint32_t difference = 0);
+  void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc, uint32_t difference = 0);
 
   std::vector<std::pair<uint32_t, uint32_t> > m_availableSlots;       //!< List of available time chunks in the DTI.
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -106,14 +106,14 @@ private:
    * Update the list of available time slots in the DTI based on some changes in previously allocated slots. 
    * The current version supports only the reduction of pre-existing allocations.
    * \param startAlloc start time of the allocation that has to be excluded from the available time.
-   * \param endAlloc end time of the allocation that has to be excluded from the available time.
+   * \param newEndAlloc new end time of the allocation that has been modified.
    * \param difference it represents how much an allocation has been reduced.
    */
-  void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc, uint32_t difference);
+  void UpdateAvailableSlots (uint32_t startAlloc, uint32_t newEndAlloc, uint32_t difference);
 
   // std::pair<uint32_t, uint32_t> is a struct used to store the start and 
   // end time (first and second member of the pair, respectively) of the available time chunks
-  std::vector<std::pair<uint32_t, uint32_t> > m_availableSlots;       //!< List of available time chunks in the DTI.
+  std::list<std::pair<uint32_t, uint32_t> > m_availableSlots;       //!< List of available time chunks in the DTI.
 
 };
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -1,0 +1,95 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2020, University of Padova, Department of Information
+ * Engineering, SIGNET Lab.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ */
+
+#ifndef PERIODIC_DMG_WIFI_SCHEDULER_H
+#define PERIODIC_DMG_WIFI_SCHEDULER_H
+
+#include "dmg-wifi-scheduler.h"
+
+namespace ns3 {
+/**
+ * \brief Scheduler  scheduling features for IEEE 802.11ad
+ *
+ * This class provides the implementation of a basic set of scheduling features
+ * for IEEE 802.11ad. In particular, this class develops the admission and control
+ * policy in the case of new ADDTS requests or modification ADDTS requests received.
+ * Also, it manages requests for periodic allocations of resources.
+ * The presence of a minimum broadcast CBAP time is considered when evaluating ADDTS requests.
+ * The remaining DTI time is allocated as broadcast CBAP.
+ */
+class PeriodicDmgWifiScheduler : public DmgWifiScheduler
+{
+public:
+  static TypeId GetTypeId (void);
+
+  PeriodicDmgWifiScheduler ();
+  virtual ~PeriodicDmgWifiScheduler ();
+
+protected:
+  virtual void DoDispose (void);
+  /**
+   * \param minAllocation The minimum acceptable allocation in us for each allocation period.
+   * \param maxAllocation The desired allocation in us for each allocation period.
+   * \return The allocation duration for the allocation period.
+   */
+  virtual uint32_t GetAllocationDuration (uint32_t minAllocation, uint32_t maxAllocation);
+  /**
+   * Implement the policy that accept, reject a new ADDTS request.
+   * \param sourceAid The AID of the requesting STA.
+   * \param dmgTspec The DMG Tspec element of the ADDTS request.
+   * \param info The DMG Allocation Info element of the request.
+   * \return The Status Code to be included in the ADDTS response.
+   */
+  virtual StatusCode AddNewAllocation (uint8_t sourceAid, const DmgTspecElement &dmgTspec, const DmgAllocationInfo &info);
+  /**
+   * Implement the policy that accept, reject a modification request.
+   * \param sourceAid The AID of the requesting STA.
+   * \param dmgTspec The DMG Tspec element of the ADDTS request.
+   * \param info The DMG Allocation Info element of the request.
+   * \return The Status Code to be included in the ADDTS response.
+   */
+  virtual StatusCode ModifyExistingAllocation (uint8_t sourceAid, const DmgTspecElement &dmgTspec, const DmgAllocationInfo &info);
+  /**
+   * Adjust the existing allocations when an allocation is removed or modified.
+   * \param iter The iterator pointing to the next element in the addtsAllocationList.
+   * \param duration The duration of the time to manage.
+   * \param isToAdd Whether the duration is to be added or subtracted.
+   */
+  virtual void AdjustExistingAllocations (AllocationFieldListI iter, uint32_t duration, bool isToAdd);
+  /**
+   * Update start time and remaining DTI time for the next request to be evaluated.
+   */
+  virtual void UpdateStartAndRemainingTime (void);
+  /**
+   * Add broadcast CBAP allocations in the DTI.
+   */
+  virtual void AddBroadcastCbapAllocations (void);
+
+private:
+
+  uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.
+  uint32_t m_interAllocationDistance;           //!< The distance between two allocations to be used as broadcast CBAP.
+
+};
+
+} // namespace ns3
+
+#endif /* PERIODIC_DMG_WIFI_SCHEDULER_H */

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -99,9 +99,7 @@ private:
    */
   void UpdateAvailableSlots (uint32_t startAllocation, uint32_t endAlloc, uint32_t difference = 0);
 
-  uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.
-  uint32_t m_interAllocationDistance;           //!< The distance between two allocations to be used as broadcast CBAP.
-  std::vector<std::pair<uint32_t, uint32_t>> m_availableSlots;       //!< List of available time chunks in the DTI.
+  std::vector<std::pair<uint32_t, uint32_t> > m_availableSlots;       //!< List of available time chunks in the DTI.
 
 };
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -84,14 +84,13 @@ protected:
   virtual void AddBroadcastCbapAllocations (void);
 
 private:
-  
   /**
-   * Verify if there is enough time in the DTI to allocate periodic SPs.
+   * Verify how many blocks (in our case, one SP correspond to one block) we can guarantee to a periodic request.
    * \param allocDuration the duration associated to the SPs.
    * \param spInterval time between two consecutive periodic SPs.
-   * \return number of SPs that can be allocated in the DTI
+   * \return number of blocks that can be allocated in the DTI
    */
-  uint8_t VerifyAvailableSlots(uint32_t allocDuration, uint32_t spInterval);
+  uint8_t GetAvailableBlocks (uint32_t allocDuration, uint32_t spInterval);
   /**
    * Update the list of available time slots in the DTI.
    * \param startAllocation start time of the allocation that has to be excluded from the available time.

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -96,8 +96,9 @@ private:
    * Update the list of available time slots in the DTI.
    * \param startAllocation start time of the allocation that has to be excluded from the available time.
    * \param endAlloc end time of the allocation that has to be excluded from the available time.
+   * \param difference if not equal to 0, it represents how much an allocation has been reduced.
    */
-  void UpdateAvailableSlots(uint32_t startAllocation, uint32_t endAlloc);
+  void UpdateAvailableSlots (uint32_t startAllocation, uint32_t endAlloc, uint32_t difference = 0);
 
   uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.
   uint32_t m_interAllocationDistance;           //!< The distance between two allocations to be used as broadcast CBAP.

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -98,9 +98,16 @@ private:
    * The current version supports only the reduction of pre-existing allocations.
    * \param startAlloc start time of the allocation that has to be excluded from the available time.
    * \param endAlloc end time of the allocation that has to be excluded from the available time.
-   * \param difference if not equal to 0, it represents how much an allocation has been reduced.
    */
-  void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc, uint32_t difference = 0);
+  void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc);
+  /**
+   * Update the list of available time slots in the DTI based on some changes in previously allocated slots. 
+   * The current version supports only the reduction of pre-existing allocations.
+   * \param startAlloc start time of the allocation that has to be excluded from the available time.
+   * \param endAlloc end time of the allocation that has to be excluded from the available time.
+   * \param difference it represents how much an allocation has been reduced.
+   */
+  void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc, uint32_t difference);
 
   // std::pair<uint32_t, uint32_t> is a struct used to store the start and 
   // end time (first and second member of the pair, respectively) of the available time chunks

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -85,7 +85,7 @@ protected:
 
 private:
 
-  void UpdateAvailableSlots(uint32_t startPeriodicAllocation, uint32_t endAlloc);
+  void UpdateAvailableSlots(uint32_t startAllocation, uint32_t endAlloc);
 
   uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.
   uint32_t m_interAllocationDistance;           //!< The distance between two allocations to be used as broadcast CBAP.

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -91,7 +91,7 @@ private:
    * In case of non-periodic request (spInterval = 0 and maxBlocksNumber = 1), check if the request fits in the DTI.
    * \param allocDuration the duration associated to the SPs.
    * \param spInterval time between two consecutive periodic SPs (= 0 if single non-periodic request).
-   * \param maxBlocksNumber maximum numbero of blocks allowed (= MAX_NUM_BLOCKS if periodic, = 1 if non-periodic)
+   * \param maxBlocksNumber maximum number of blocks allowed (= MAX_NUM_BLOCKS if periodic, = 1 if non-periodic)
    * \return list corresponding to the starting time of each block to be allocated
    */
   std::vector<uint32_t> GetAvailableBlocks (uint32_t allocDuration, uint32_t spInterval, uint8_t maxBlocksNumber);

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -85,8 +85,11 @@ protected:
 
 private:
 
+  void UpdateAvailableSlots(uint32_t startPeriodicAllocation, uint32_t endAlloc);
+
   uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.
   uint32_t m_interAllocationDistance;           //!< The distance between two allocations to be used as broadcast CBAP.
+  std::vector<std::pair<uint32_t, uint32_t>> m_availableSlots;       //!< List of available time chunks in the DTI.
 
 };
 

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -46,13 +46,14 @@ public:
 protected:
   virtual void DoDispose (void);
   /**
+   * Evaluate the duration of the allocation based on the minumum and maximum duration constraints
    * \param minAllocation The minimum acceptable allocation in us for each allocation period.
    * \param maxAllocation The desired allocation in us for each allocation period.
    * \return The allocation duration for the allocation period.
    */
   virtual uint32_t GetAllocationDuration (uint32_t minAllocation, uint32_t maxAllocation);
   /**
-   * Implement the policy that accept, reject a new ADDTS request.
+   * Implement the policy that accepts or rejects a new ADDTS request.
    * \param sourceAid The AID of the requesting STA.
    * \param dmgTspec The DMG Tspec element of the ADDTS request.
    * \param info The DMG Allocation Info element of the request.
@@ -60,11 +61,12 @@ protected:
    */
   virtual StatusCode AddNewAllocation (uint8_t sourceAid, const DmgTspecElement &dmgTspec, const DmgAllocationInfo &info);
   /**
-   * Implement the policy that accept, reject a modification request.
+   * Implement the policy that accepts or rejects a modification request.
+   * The current version supports only requests of reduction of the duration of the allocations.
    * \param sourceAid The AID of the requesting STA.
    * \param dmgTspec The DMG Tspec element of the ADDTS request.
    * \param info The DMG Allocation Info element of the request.
-   * \return The Status Code to be included in the ADDTS response.
+   * \return The StatusCode to be included in the ADDTS response.
    */
   virtual StatusCode ModifyExistingAllocation (uint8_t sourceAid, const DmgTspecElement &dmgTspec, const DmgAllocationInfo &info);
   /**
@@ -85,20 +87,23 @@ protected:
 
 private:
   /**
-   * Verify how many blocks (in our case, one SP correspond to one block) we can guarantee to a periodic request.
+   * Verify how many blocks (in our case, one SP corresponds to one block) we can guarantee to a periodic request.
    * \param allocDuration the duration associated to the SPs.
    * \param spInterval time between two consecutive periodic SPs.
    * \return number of blocks that can be allocated in the DTI
    */
   uint8_t GetAvailableBlocks (uint32_t allocDuration, uint32_t spInterval);
   /**
-   * Update the list of available time slots in the DTI.
+   * Update the list of available time slots in the DTI. 
+   * The current version supports only the reduction of pre-existing allocations.
    * \param startAlloc start time of the allocation that has to be excluded from the available time.
    * \param endAlloc end time of the allocation that has to be excluded from the available time.
    * \param difference if not equal to 0, it represents how much an allocation has been reduced.
    */
   void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc, uint32_t difference = 0);
-
+  
+  // std::pair<uint32_t, uint32_t> is a struct used to store the start and 
+  // end time (first and second member of the pair, respectively) of the available time chunks
   std::vector<std::pair<uint32_t, uint32_t> > m_availableSlots;       //!< List of available time chunks in the DTI.
 
 };

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -101,7 +101,7 @@ private:
    * \param difference if not equal to 0, it represents how much an allocation has been reduced.
    */
   void UpdateAvailableSlots (uint32_t startAlloc, uint32_t endAlloc, uint32_t difference = 0);
-  
+
   // std::pair<uint32_t, uint32_t> is a struct used to store the start and 
   // end time (first and second member of the pair, respectively) of the available time chunks
   std::vector<std::pair<uint32_t, uint32_t> > m_availableSlots;       //!< List of available time chunks in the DTI.

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -88,11 +88,13 @@ protected:
 private:
   /**
    * Verify how many blocks (in our case, one SP corresponds to one block) we can guarantee to a periodic request.
+   * In case of non-periodic request (spInterval = 0 and maxBlocksNumber = 1), check if the request fits in the DTI.
    * \param allocDuration the duration associated to the SPs.
-   * \param spInterval time between two consecutive periodic SPs.
-   * \return number of blocks that can be allocated in the DTI
+   * \param spInterval time between two consecutive periodic SPs (= 0 if single non-periodic request).
+   * \param maxBlocksNumber maximum numbero of blocks allowed (= MAX_NUM_BLOCKS if periodic, = 1 if non-periodic)
+   * \return list corresponding to the starting time of each block to be allocated
    */
-  uint8_t GetAvailableBlocks (uint32_t allocDuration, uint32_t spInterval);
+  std::vector<uint32_t> GetAvailableBlocks (uint32_t allocDuration, uint32_t spInterval, uint8_t maxBlocksNumber);
   /**
    * Update the list of available time slots in the DTI. 
    * The current version supports only the reduction of pre-existing allocations.

--- a/src/wifi/model/periodic-dmg-wifi-scheduler.h
+++ b/src/wifi/model/periodic-dmg-wifi-scheduler.h
@@ -92,6 +92,11 @@ private:
    * \return number of SPs that can be allocated in the DTI
    */
   uint8_t VerifyAvailableSlots(uint32_t allocDuration, uint32_t spInterval);
+  /**
+   * Update the list of available time slots in the DTI.
+   * \param startAllocation start time of the allocation that has to be excluded from the available time.
+   * \param endAlloc end time of the allocation that has to be excluded from the available time.
+   */
   void UpdateAvailableSlots(uint32_t startAllocation, uint32_t endAlloc);
 
   uint32_t m_minBroadcastCbapDuration;          //!< The minimum duration of a broadcast CBAP to be present in the DTI.

--- a/src/wifi/wscript
+++ b/src/wifi/wscript
@@ -101,6 +101,7 @@ def build(bld):
         'model/dmg-wifi-scheduler.cc',
         'model/basic-dmg-wifi-scheduler.cc',
         'model/cbap-only-dmg-wifi-scheduler.cc',
+        'model/periodic-dmg-wifi-scheduler.cc',
         'model/dmg-wifi-channel.cc',
         'model/dmg-wifi-phy.cc',
         'model/ext-headers.cc',
@@ -194,8 +195,8 @@ def build(bld):
         'model/capability-information.h',
         'model/dcf-manager.h',
         'model/dcf-state.h',
-        'model/mac-tx-middle.h', 
-        'model/mac-rx-middle.h', 
+        'model/mac-tx-middle.h',
+        'model/mac-rx-middle.h',
         'model/mac-low.h',
         'model/mac-low-transmission-parameters.h',
         'model/originator-block-ack-agreement.h',
@@ -234,6 +235,7 @@ def build(bld):
         'model/dmg-wifi-scheduler.h',
         'model/basic-dmg-wifi-scheduler.h',
         'model/cbap-only-dmg-wifi-scheduler.h',
+        'model/periodic-dmg-wifi-scheduler.h',
         'model/common-header.h',
         'model/codebook.h',
         'model/codebook-numerical.h',
@@ -277,4 +279,3 @@ def build(bld):
         bld.recurse('examples')
 
     bld.ns3_python_bindings()
-


### PR DESCRIPTION
This is a basic proposal to implement periodic allocations into our version of the scheduler. The code is backward compatible, i.e., also non-periodic requests are considered and the remaining time gaps on the DTI are considered as CBAP time. Where possible, all for loops have been substituted by range-based for loops.

IMHO the code is well documented (and I wrote meaningful commit messages, hopefully) so it shouldn't be necessary to explain line-by-line what I coded. However, there are few assumptions that need to be considered to clarify what is supported and what's not:

- `m_availableSlots` is now the key attribute for managing all the requests.
- Multiple BI periodicity is not supported.
- For existing allocations, `ModifyExistingAllocation` considers only the duration; as of now, only decreasing the current duration is possible, while the increase is not supported by this version of the scheduler.
- `AdjustExistingAllocation` considers just the update of `m_availableSlots`, based on changes to `m_addtsAllocationList` carried out inside `DmgWifiScheduler`.
- As of now, a periodic allocation is accepted only if the scheduler can guarantee at least 2 blocks inside the DTI (in our realization of the scheduler, 1 block = 1 SP).

The code has been tested with different combinations to check if everything was allocated correctly. **However**, when and if it will be used, I suggest to enable the logs and double check if it works properly. I worked hard to try to cover all the possible conditions, but still. 